### PR TITLE
[sc-139757] Allow project LD proj/env overrides to be clear

### DIFF
--- a/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
@@ -12,6 +12,7 @@ import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.dsl.builder.*
 import com.launchdarkly.api.ApiException
 import com.launchdarkly.api.model.Environment
+import com.launchdarkly.api.model.Project as LDProject
 import com.launchdarkly.intellij.LaunchDarklyApiClient
 import com.launchdarkly.intellij.messaging.DefaultMessageBusService
 import javax.swing.DefaultComboBoxModel
@@ -105,8 +106,8 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
     private var projectUpdatedSelection = false
     private var envUpdatedSelection = false
     private var lastSelectedProject = ""
-    private lateinit var projectContainer: MutableList<com.launchdarkly.api.model.Project>
-    private lateinit var environmentContainer: com.launchdarkly.api.model.Project
+    private lateinit var projectContainer: MutableList<LDProject>
+    private lateinit var environmentContainer: LDProject
 
     private lateinit var defaultMessage: String
     private lateinit var projectBox: DefaultComboBoxModel<String>
@@ -117,7 +118,7 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
             projectContainer = getProjects(null, null)
             if (projectContainer.size > 0) {
                 environmentContainer = projectContainer.find { it.key == settings.project }
-                    ?: projectContainer.firstOrNull() as com.launchdarkly.api.model.Project
+                    ?: projectContainer.firstOrNull() as LDProject
             }
         } catch (err: Exception) {
             defaultMessage = "Check API Key"
@@ -284,15 +285,15 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
 
     }
 
-    private fun getProjects(apiKey: String?, baseUri: String?): MutableList<com.launchdarkly.api.model.Project> {
+    private fun getProjects(apiKey: String?, baseUri: String?): MutableList<LDProject> {
         val projectApi = LaunchDarklyApiClient.projectInstance(project, apiKey, baseUri)
         val projectList = projectApi.projects.items.sortedBy { it.key }
         val noProjList = listOf(noProj())
-        return (noProjList + projectList) as MutableList<com.launchdarkly.api.model.Project>
+        return (noProjList + projectList) as MutableList<LDProject>
     }
 
-    private fun tmpProj(): com.launchdarkly.api.model.Project {
-        val tempProj = com.launchdarkly.api.model.Project()
+    private fun tmpProj(): LDProject {
+        val tempProj = LDProject()
         tempProj.key = "Check API and baseURL"
         val tempEnv = Environment()
         tempEnv.key("Check API and baseURL")
@@ -300,8 +301,8 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
         return tempProj
     }
 
-    private fun noProj(): com.launchdarkly.api.model.Project {
-        val tempProj = com.launchdarkly.api.model.Project()
+    private fun noProj(): LDProject {
+        val tempProj = LDProject()
         tempProj.key = ""
         val tempEnv = Environment()
         tempEnv.key("")

--- a/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
@@ -143,7 +143,7 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
                     DefaultComboBoxModel(arrayOf(defaultMessage))
                 }
                 row("Project") {
-                    val projectComboBox = comboBox(projectBox, renderer).bindItem(settings::project).component.addActionListener {
+                    comboBox(projectBox, renderer).bindItem(settings::project).component.addActionListener {
                         projectUpdatedSelection = true
                     }
                     button("Clear") {

--- a/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
@@ -21,8 +21,7 @@ import javax.swing.JPanel
  * Maintain state of what LaunchDarkly Project to connect to.
  */
 @State(name = "LaunchDarklyConfig", storages = [Storage("launchdarkly.xml")])
-open class LaunchDarklyConfig(project: Project) : PersistentStateComponent<LaunchDarklyConfig.ConfigState> {
-    val project: Project = project
+open class LaunchDarklyConfig(val project: Project) : PersistentStateComponent<LaunchDarklyConfig.ConfigState> {
     var ldState: ConfigState = ConfigState()
 
     companion object {

--- a/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
@@ -148,6 +148,7 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
                     }
                     button("Clear") {
                         projectBox.setSelectedItem(projectBox.getElementAt(0))
+                        modified = true
                     }
                 }
 

--- a/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
@@ -143,8 +143,11 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
                     DefaultComboBoxModel(arrayOf(defaultMessage))
                 }
                 row("Project") {
-                    comboBox(projectBox, renderer).bindItem(settings::project).component.addActionListener {
+                    val projectComboBox = comboBox(projectBox, renderer).bindItem(settings::project).component.addActionListener {
                         projectUpdatedSelection = true
+                    }
+                    button("Clear") {
+                        projectBox.setSelectedItem(projectBox.getElementAt(0))
                     }
                 }
 
@@ -284,7 +287,9 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
 
     private fun getProjects(apiKey: String?, baseUri: String?): MutableList<com.launchdarkly.api.model.Project> {
         val projectApi = LaunchDarklyApiClient.projectInstance(project, apiKey, baseUri)
-        return projectApi.projects.items.sortedBy { it.key } as MutableList<com.launchdarkly.api.model.Project>
+        val projectList = projectApi.projects.items.sortedBy { it.key }
+        val noProjList = listOf(noProj())
+        return (noProjList + projectList) as MutableList<com.launchdarkly.api.model.Project>
     }
 
     private fun tmpProj(): com.launchdarkly.api.model.Project {
@@ -293,6 +298,15 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
         val tempEnv = Environment()
         tempEnv.key("Check API and baseURL")
         tempProj.environments = listOf<Environment>(tempEnv)
+        return tempProj
+    }
+
+    private fun noProj(): com.launchdarkly.api.model.Project {
+        val tempProj = com.launchdarkly.api.model.Project()
+        tempProj.key = ""
+        val tempEnv = Environment()
+        tempEnv.key("")
+        tempProj.environments = listOf(tempEnv)
         return tempProj
     }
 

--- a/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
@@ -16,7 +16,6 @@ import com.launchdarkly.intellij.LaunchDarklyApiClient
 import com.launchdarkly.intellij.messaging.DefaultMessageBusService
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JPanel
-import javax.swing.JPasswordField
 
 /*
  * Maintain state of what LaunchDarkly Project to connect to.
@@ -107,8 +106,8 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
     private var projectUpdatedSelection = false
     private var envUpdatedSelection = false
     private var lastSelectedProject = ""
-    lateinit var projectContainer: MutableList<com.launchdarkly.api.model.Project>
-    lateinit var environmentContainer: com.launchdarkly.api.model.Project
+    private lateinit var projectContainer: MutableList<com.launchdarkly.api.model.Project>
+    private lateinit var environmentContainer: com.launchdarkly.api.model.Project
 
     private lateinit var defaultMessage: String
     private lateinit var projectBox: DefaultComboBoxModel<String>
@@ -181,8 +180,7 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
                 if (settings.credName != project.name) settings.credName = project.name
                 settings.credName = project.name
             }
-            var uri: String
-            uri = if (settings.baseUri != origBaseUri) {
+            val uri = if (settings.baseUri != origBaseUri) {
                 if (settings.baseUri != "") settings.baseUri else mergedSettings.baseUri
             } else {
                 mergedSettings.baseUri
@@ -228,7 +226,7 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
             lastSelectedProject = projectBox.selectedItem.toString()
             try {
                 val tempProj = tmpProj()
-                var projCont = projectContainer.find { it.key == projectBox?.selectedItem?.toString() } ?: tempProj
+                val projCont = projectContainer.find { it.key == projectBox?.selectedItem?.toString() } ?: tempProj
 
                 environmentContainer = projCont
                 val envMap = environmentContainer.environments.map { it.key }.sorted()
@@ -284,12 +282,12 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
 
     }
 
-    fun getProjects(apiKey: String?, baseUri: String?): MutableList<com.launchdarkly.api.model.Project> {
+    private fun getProjects(apiKey: String?, baseUri: String?): MutableList<com.launchdarkly.api.model.Project> {
         val projectApi = LaunchDarklyApiClient.projectInstance(project, apiKey, baseUri)
         return projectApi.projects.items.sortedBy { it.key } as MutableList<com.launchdarkly.api.model.Project>
     }
 
-    fun tmpProj(): com.launchdarkly.api.model.Project {
+    private fun tmpProj(): com.launchdarkly.api.model.Project {
         val tempProj = com.launchdarkly.api.model.Project()
         tempProj.key = "Check API and baseURL"
         val tempEnv = Environment()

--- a/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklySettings.kt
@@ -196,13 +196,13 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
                 } else {
                     if (!::projectContainer.isInitialized) {
                         val tempProj = tmpProj()
-                        projectContainer = mutableListOf<com.launchdarkly.api.model.Project>(tempProj)
+                        projectContainer = mutableListOf(tempProj)
                     }
                 }
             } catch (err: ApiException) {
                 if (!::projectContainer.isInitialized) {
                     val tempProj = tmpProj()
-                    projectContainer = mutableListOf<com.launchdarkly.api.model.Project>(tempProj)
+                    projectContainer = mutableListOf(tempProj)
                 }
             }
             with(projectBox) {
@@ -297,7 +297,7 @@ class LaunchDarklyConfigurable(private val project: Project) : BoundConfigurable
         tempProj.key = "Check API and baseURL"
         val tempEnv = Environment()
         tempEnv.key("Check API and baseURL")
-        tempProj.environments = listOf<Environment>(tempEnv)
+        tempProj.environments = listOf(tempEnv)
         return tempProj
     }
 


### PR DESCRIPTION
- Adds an "empty" project option to dropdown
- Adds a clear button that sets proj/env to "empty"
- Minor lint fixes (recommendations from IntelliJ Problems console)

**Open to feedback on UX**
<img width="498" alt="CleanShot 2022-02-03 at 11 02 50@2x" src="https://user-images.githubusercontent.com/4053924/152380643-c7ef8427-51d6-4531-9198-137f8f73b519.png">

## Testing

1. Set global configuration & apply - make sure LD toolbar with flags is open to see flags populate
2. Go to Project Overrides and set proj/env
3. Hit apply and see LD toolbar refresh
4. Select **Clear**, Hit apply and see LD toolbar refresh to global settings