### PR TITLE
Make root item open the environment

### DIFF
--- a/src/main/kotlin/com/launchdarkly/intellij/action/CopyKeyAction.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/action/CopyKeyAction.kt
@@ -3,7 +3,10 @@ package com.launchdarkly.intellij.action
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service
+import com.launchdarkly.intellij.toolwindow.FlagNodeBase
+import com.launchdarkly.intellij.toolwindow.FlagNodeParent
 import com.launchdarkly.intellij.toolwindow.FlagToolWindow
+import com.launchdarkly.intellij.toolwindow.InfoNode
 import java.awt.Toolkit
 import java.awt.datatransfer.Clipboard
 import java.awt.datatransfer.StringSelection
@@ -73,10 +76,11 @@ class CopyKeyAction : AnAction {
         if (project != null) {
             if (project.service<FlagToolWindow>().getPanel().tree.lastSelectedPathComponent != null) {
                 val selectedNode =
-                    project.service<FlagToolWindow>().getPanel().tree.lastSelectedPathComponent.toString()
+                    project.service<FlagToolWindow>().getPanel().tree.lastSelectedPathComponent as DefaultMutableTreeNode
+                val isFlagParentNode = selectedNode.userObject as? FlagNodeParent
+
                 e.presentation.isEnabledAndVisible =
-                    e.presentation.isEnabled && (selectedNode.startsWith("Key:") || project.service<FlagToolWindow>()
-                        .getPanel().tree.selectionPath.path.size == FLAG_NAME_PATH)
+                    e.presentation.isEnabled && (selectedNode.toString().startsWith("Key:") || isFlagParentNode != null)
             }
         } else {
             e.presentation.isEnabledAndVisible = false

--- a/src/main/kotlin/com/launchdarkly/intellij/action/OpenInBrowserAction.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/action/OpenInBrowserAction.kt
@@ -8,6 +8,7 @@ import com.launchdarkly.intellij.settings.LaunchDarklyMergedSettings
 import com.launchdarkly.intellij.toolwindow.FlagNodeParent
 import com.launchdarkly.intellij.toolwindow.FlagToolWindow
 import com.launchdarkly.intellij.notifications.GeneralNotifier
+import com.launchdarkly.intellij.toolwindow.FlagNodeBase
 import javax.swing.Icon
 import javax.swing.tree.DefaultMutableTreeNode
 
@@ -52,11 +53,15 @@ class OpenInBrowserAction : AnAction {
         if (project.service<FlagToolWindow>().getPanel().tree.lastSelectedPathComponent !== null) {
             val selectedNode =
                 project.service<FlagToolWindow>().getPanel().tree.lastSelectedPathComponent as DefaultMutableTreeNode
-            val nodeInfo: FlagNodeParent = selectedNode.userObject as FlagNodeParent
-            if (nodeInfo != null) {
-                val url = "${settings.baseUri}/${settings.project}/${settings.environment}/features/${nodeInfo.flag.key}"
-                BrowserLauncher.instance.open(url)
-            }
+            // If cast fails, it means the root node with project/env info was selected, so we'll open that.
+            val nodeInfo: FlagNodeParent? = selectedNode.userObject as? FlagNodeParent
+                if (nodeInfo != null) {
+                    val url = "${settings.baseUri}/${settings.project}/${settings.environment}/features/${nodeInfo.flag.key}"
+                    BrowserLauncher.instance.open(url)
+                } else {
+                    val url = "${settings.baseUri}/${settings.project}/${settings.environment}/features"
+                    BrowserLauncher.instance.open(url)
+                }
         } else {
             val notifier = GeneralNotifier()
             notifier.notify(project, "Error opening in browser, please try again.")

--- a/src/main/kotlin/com/launchdarkly/intellij/action/ToggleFlagAction.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/action/ToggleFlagAction.kt
@@ -91,10 +91,10 @@ class ToggleFlagAction : AnAction {
         val project = e.project
         if (project != null) {
             if (project.service<FlagToolWindow>().getPanel().tree.selectionPath != null) {
-                val nodePath = project.service<FlagToolWindow>().getPanel().tree.selectionPath.path
-                if (nodePath != null && nodePath.size == FLAG_NAME_PATH) {
-                    e.presentation.isEnabledAndVisible = e.presentation.isEnabled
-                }
+                val selectedNode = project.service<FlagToolWindow>().getPanel().tree.lastSelectedPathComponent as DefaultMutableTreeNode
+                val isFlagNode = selectedNode.userObject as? FlagNodeParent
+
+                e.presentation.isEnabledAndVisible = e.presentation.isEnabled && isFlagNode != null
             } else {
                 e.presentation.isEnabledAndVisible = false
             }

--- a/src/main/kotlin/com/launchdarkly/intellij/toolwindow/FlagNode.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/toolwindow/FlagNode.kt
@@ -16,7 +16,7 @@ class RootNode(private val flags: FeatureFlags, private val settings: LDSettings
     override fun getChildren(): Array<SimpleNode> {
         when {
             myChildren.isEmpty() && flags.items != null -> {
-                myChildren.add(FlagNodeBase("${settings.project} / ${settings.environment}", LDIcons.LOGO))
+                myChildren.add(InfoNode("${settings.project} / ${settings.environment}", ))
                 for (flag in flags.items) {
                     myChildren.add(FlagNodeParent(flag, flags, intProject))
                 }

--- a/src/main/kotlin/com/launchdarkly/intellij/toolwindow/InfoNode.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/toolwindow/InfoNode.kt
@@ -1,0 +1,18 @@
+package com.launchdarkly.intellij.toolwindow
+
+import com.intellij.ide.projectView.PresentationData
+import com.intellij.ui.treeStructure.SimpleNode
+import com.launchdarkly.intellij.LDIcons
+
+class InfoNode(var label: String) : SimpleNode() {
+    override fun getChildren(): Array<SimpleNode> {
+        return SimpleNode.NO_CHILDREN
+    }
+
+    override fun update(data: PresentationData) {
+        super.update(data)
+        data.presentableText = label
+        data.tooltip = label
+        data.setIcon(LDIcons.LOGO)
+    }
+}


### PR DESCRIPTION
Rather than entirely removing the context here, we can easily open the Environment window, since that's what the node is relating to.