### PR TITLE
remove use of Panel.indent for compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Removed
 
 ### Fixed
+- Invalid layout function in plugin settings
 
 ### Security
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 pluginGroup=com.github.intheclouddan.intellijpluginld
 pluginName=intellij-plugin-ld
-pluginVersion=0.5.0-idea22
+pluginVersion=0.5.1-idea22
 pluginSinceBuild=213.6461.79
 pluginUntilBuild=221.*
 platformType=IC

--- a/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklyApplicationSettings.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/settings/LaunchDarklyApplicationSettings.kt
@@ -181,15 +181,12 @@ class LaunchDarklyApplicationConfigurable : BoundConfigurable(displayName = "Lau
                 lateinit var enableCodeRefs: Cell<JBCheckBox>
                 row {
                     enableCodeRefs = checkBox("Use Code References").bindSelected(settings::codeReferences)
-                }
-                indent {
-                    row {
-                        intTextField()
-                            .label("Refresh every")
-                            .bindIntText(settings::codeReferencesRefreshRate)
-                            .gap(RightGap.SMALL)
-                        label("minutes")
-                    }.enabledIf(enableCodeRefs.selected)
+                    intTextField()
+                        .label("Refresh every")
+                        .bindIntText(settings::codeReferencesRefreshRate)
+                        .gap(RightGap.SMALL)
+                        .enabledIf(enableCodeRefs.selected)
+                    label("minutes").enabledIf(enableCodeRefs.selected)
                 }
             }
         }


### PR DESCRIPTION
0.5.0 was [not approved](https://plugins.jetbrains.com/plugin/15159-launchdarkly/versions/beta/162069) because:

```
IntelliJ IDEA Ultimate IU-221.4994.441 compatibility problem. 2 usages of scheduled for removal API and 6 usages of deprecated API ([Restart]())
1 compatibility problem
LaunchDarkly 0.5.0-idea22 is binary incompatible with IntelliJ IDEA Ultimate IU-221.4994.44 due to the following problem
Method not found (1 problem)
Invocation of unresolved method Panel.indent(Function1) (1 problem)
Method LaunchDarklyApplicationConfigurable.createPanel$1$9.invoke(...) contains an invokeinterface instruction referencing an unresolved method Panel.indent(Function1). This can lead to NoSuchMethodError exception at runtime.
The method might have been declared in the super interface: CellBase
```

Removed indent and moved setting to one row
<img width="484" alt="CleanShot 2022-03-14 at 10 56 31@2x" src="https://user-images.githubusercontent.com/4053924/158198823-ce2816a8-8093-4f84-8f9b-55cb4374851f.png">

<img width="480" alt="CleanShot 2022-03-14 at 10 56 38@2x" src="https://user-images.githubusercontent.com/4053924/158198856-d1f1a093-5e9e-4419-b0e8-73095fcaf4cc.png">
