### PR TITLE
Copy flag key occasionally does not work

### DIFF
--- a/src/main/kotlin/com/launchdarkly/intellij/action/CopyKeyAction.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/action/CopyKeyAction.kt
@@ -3,15 +3,17 @@ package com.launchdarkly.intellij.action
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service
+import com.launchdarkly.intellij.notifications.GeneralNotifier
 import com.launchdarkly.intellij.toolwindow.FlagNodeParent
 import com.launchdarkly.intellij.toolwindow.FlagToolWindow
+import com.launchdarkly.intellij.toolwindow.KEY_PREFIX
 import java.awt.Toolkit
 import java.awt.datatransfer.Clipboard
 import java.awt.datatransfer.StringSelection
 import javax.swing.Icon
 import javax.swing.tree.DefaultMutableTreeNode
+import kotlinx.coroutines.selects.select
 
-const val FLAG_NAME_DEPTH = 1
 const val FLAG_NAME_PATH = 2
 
 /**
@@ -45,21 +47,27 @@ class CopyKeyAction : AnAction {
      */
     override fun actionPerformed(event: AnActionEvent) {
         val project = event.project
-        var selection = StringSelection("")
         if (project != null) {
-            val selectedNode =
+            var selectedNode =
                 project.service<FlagToolWindow>().getPanel()
-                    .getFlagPanel().tree.lastSelectedPathComponent as DefaultMutableTreeNode
-            if (selectedNode != null) {
-                // Right clicking on Key node. Will break if order changes.
-                if (selectedNode.childCount == 0 && selectedNode.toString().startsWith("Key:")) {
-                    selection = StringSelection(selectedNode.toString().substringAfter(" "))
-                } else if (selectedNode.depth == FLAG_NAME_DEPTH) { //
-                    selection = StringSelection(selectedNode.firstChild.toString().substringAfter(" "))
+                    .getFlagPanel().tree.lastSelectedPathComponent as? DefaultMutableTreeNode
+            while (selectedNode != null) {
+                if (selectedNode.userObject is FlagNodeParent) {
+                    val flagNodeParent = selectedNode.userObject as FlagNodeParent
+                    val selection = StringSelection(flagNodeParent.key)
+                    val clipboard: Clipboard = Toolkit.getDefaultToolkit().systemClipboard
+                    return clipboard.setContents(selection, selection)
+                } else {
+                    selectedNode = selectedNode.parent as? DefaultMutableTreeNode
                 }
-                val clipboard: Clipboard = Toolkit.getDefaultToolkit().systemClipboard
-                clipboard.setContents(selection, selection)
             }
+
+            // If we can't find the key to copy, notify the user
+            val notifier = GeneralNotifier()
+            notifier.notify(
+                project,
+                "Could not copy flag key."
+            )
         }
     }
 
@@ -74,15 +82,17 @@ class CopyKeyAction : AnAction {
         if (project != null) {
             if (project.service<FlagToolWindow>().getPanel().getFlagPanel().tree.lastSelectedPathComponent != null) {
                 val selectedNode =
-                    project.service<FlagToolWindow>()
-                        .getPanel().getFlagPanel().tree.lastSelectedPathComponent as DefaultMutableTreeNode
-                val isFlagParentNode = selectedNode.userObject as? FlagNodeParent
+                        project.service<FlagToolWindow>()
+                                .getPanel().getFlagPanel().tree.lastSelectedPathComponent as DefaultMutableTreeNode
+                val isFlagParentNode = selectedNode.userObject is FlagNodeParent
+                val hasKeyPrefix = selectedNode.toString().startsWith(KEY_PREFIX)
 
-                e.presentation.isEnabledAndVisible =
-                    e.presentation.isEnabled && (selectedNode.toString().startsWith("Key:") || isFlagParentNode != null)
+                e.presentation.isEnabledAndVisible = e.presentation.isEnabled && (hasKeyPrefix || isFlagParentNode)
             }
         } else {
             e.presentation.isEnabledAndVisible = false
         }
     }
+
+
 }

--- a/src/main/kotlin/com/launchdarkly/intellij/action/CopyKeyAction.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/action/CopyKeyAction.kt
@@ -12,7 +12,6 @@ import java.awt.datatransfer.Clipboard
 import java.awt.datatransfer.StringSelection
 import javax.swing.Icon
 import javax.swing.tree.DefaultMutableTreeNode
-import kotlinx.coroutines.selects.select
 
 const val FLAG_NAME_PATH = 2
 
@@ -82,8 +81,8 @@ class CopyKeyAction : AnAction {
         if (project != null) {
             if (project.service<FlagToolWindow>().getPanel().getFlagPanel().tree.lastSelectedPathComponent != null) {
                 val selectedNode =
-                        project.service<FlagToolWindow>()
-                                .getPanel().getFlagPanel().tree.lastSelectedPathComponent as DefaultMutableTreeNode
+                    project.service<FlagToolWindow>()
+                        .getPanel().getFlagPanel().tree.lastSelectedPathComponent as DefaultMutableTreeNode
                 val isFlagParentNode = selectedNode.userObject is FlagNodeParent
                 val hasKeyPrefix = selectedNode.toString().startsWith(KEY_PREFIX)
 
@@ -93,6 +92,4 @@ class CopyKeyAction : AnAction {
             e.presentation.isEnabledAndVisible = false
         }
     }
-
-
 }

--- a/src/main/kotlin/com/launchdarkly/intellij/toolwindow/FlagNodeParent.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/toolwindow/FlagNodeParent.kt
@@ -11,6 +11,8 @@ import com.launchdarkly.intellij.LDIcons
 import com.launchdarkly.intellij.featurestore.FlagConfiguration
 import java.util.*
 
+const val KEY_PREFIX = "Key:"
+
 class FlagNodeParent(FFlag: FeatureFlag, private var flags: FeatureFlags, myProject: Project) : SimpleNode() {
     private var children: MutableList<SimpleNode> = ArrayList()
     private val getFlags = myProject.service<FlagStore>()
@@ -30,7 +32,7 @@ class FlagNodeParent(FFlag: FeatureFlag, private var flags: FeatureFlags, myProj
     }
 
     private fun buildChildren() {
-        children.add(FlagNodeBase("Key: ${flag.key}", LDIcons.FLAG_KEY))
+        children.add(FlagNodeBase("$KEY_PREFIX ${flag.key}", LDIcons.FLAG_KEY))
         if (flag.description != "") children.add(FlagNodeBase("Description: ${flag.description}", LDIcons.DESCRIPTION))
         children.add(FlagNodeVariations(flag))
 


### PR DESCRIPTION
The `CopyKeyAction` became flakey as it depended on string matching the node, or evaluating the depth of the node to determine if we could extract the flag key from the name. Instead we now rely on the backing `userObject` and find the node's corresponding `FlagNodeParent` and use the `key` property to populate the clipboard. 

If for some reason we can't find a parent, we notify the user with an error. 

![image](https://user-images.githubusercontent.com/1693328/158681336-d8bfc9b7-f8c1-4315-a912-17b683d4b8df.png)
