### PR TITLE
[sc-146353] Disable hover if language is not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 ## [Unreleased]
+
 ### Added
 
 ### Changed
@@ -14,6 +15,7 @@
 ### Security
 
 ## [0.5.1-idea22]
+
 ### Added
 
 ### Changed
@@ -23,52 +25,70 @@
 ### Removed
 
 ### Fixed
+
 - Invalid layout function in plugin settings
+- Erroneous hover information over flag keys
 
 ### Security
 
 ## [0.5.0-idea22]
+
 ### Added
+
 - Quick links panel
 
 ### Changed
+
 - Merged non-project settings into one Advanced section
 
 ### Removed
+
 - Project override settings
 
 ### Fixed
+
 - Code completion for flag keys
 
 ## [0.4.0-idea22]
+
 ### Fixed
+
 - Top info node showing project/environment info errored when opening in browser.
 - Better error handling for API failures
 - Fixed rotated icon in dark theme mode
 
 ### Changed
+
 - Right-click context item `Toggle Flag` is now more limited on which nodes it is attached to.
 
 ### Added
+
 - Update Preferences to have a `Get Projects` button to fetch projects after adding API Key.
 
 ## [0.3.8]
+
 ### Changed
+
 - Project override no longer supports a separate API key
 - Update build compatibility
 - Wrap get flags API call in try/catch
 
 ### Fixed
+
 - NPE error when switching environments and trying to open in browser
 
 ## [0.3.4]
 
 ## [0.3.3]
+
 ### Fixed
+
 - Verify feature store setup is always on background thread.
 
 ## [0.3.2]
+
 ### Fixed
+
 - Revert Notifications Class until 2021.2
 - Fix check for coderefs config file
 
@@ -79,7 +99,9 @@
 ### Fixed
 
 ## [0.3.1]
+
 ### Fixed
+
 - Using only Project Overrides Configuration would throw an error
 - Use InvokeLater for any threads affecting the UI
 - Check for coderefs.yaml to exist before scheduling to run
@@ -87,6 +109,7 @@
 ### Fixed
 
 ### Added
+
 - Support for 2021 EAP
 
 ## [0.3.1] - 2021-02-25
@@ -94,19 +117,23 @@
 ### Added
 
 ## [0.3.0]
+
 ### Fixed
+
 - When selecting a project in Project Override settings it would revert to first in list
 - Hover throwing NPE if flags were not loaded
 
 ### Fixed
 
 ### Changed
+
 - Load flags for flag panel in background thread
 - Do not show SVG on hover until YouTrack issue is fixed
 
 ### Changed
 
 ### Added
+
 - Code References will be downloaded and run based setting interval
 
 ## [0.3.0] - 2021-02-23
@@ -114,12 +141,15 @@
 ### Added
 
 ## [0.2.0]
+
 ### Fixed
+
 - Debug logging that was left in the code
 
 ### Fixed
 
 ### Added
+
 - Code References will be downloaded and run based setting interval
 
 ## [0.2.0] - 2021-01-06
@@ -127,7 +157,9 @@
 ### Added
 
 ## [0.1.12]
+
 ### Fixed
+
 - Handle stream connections in separate thread
 
 ### Fixed
@@ -135,6 +167,7 @@
 ### Fixed
 
 ### Changed
+
 - DocumentationProvider should work for all languages now, not just JVM
 
 ## [0.1.12] - 2020-12-29
@@ -144,12 +177,15 @@
 ### Changed
 
 ## [0.1.11-alpha]
+
 ### Fixed
+
 - Handling stream connection not being available
 
 ### Fixed
 
 ### Changed
+
 - Icons for Toggle State have been updated
 - DocumentationProvider should work for all languages now, not just JVM
 
@@ -158,12 +194,15 @@
 ### Changed
 
 ## [0.1.10-alpha]
+
 ### Removed
+
 - External Documentation override
 
 ### Removed
 
 ### Added
+
 - External link inside of DocumentationHover
 
 ## [0.1.10-alpha] - 2020-12-14
@@ -171,18 +210,22 @@
 ### Added
 
 ## [0.1.9-alpha]
+
 ### Removed
+
 - Defaults from treeview
 
 ### Removed
 
 ### Added
+
 - External link for hovers
 - Show default rule rollout percentage on hover
 
 ### Added
 
 ### Changed
+
 - Hover layout
 
 ## [0.1.9-alpha] - 2020-12-09
@@ -190,7 +233,9 @@
 ### Changed
 
 ## [0.1.8-alpha]
+
 ### Changed
+
 - Minor updates to Java Documentation Hover Provider
 - Searching treeview will include matches on flag key
 
@@ -199,7 +244,9 @@
 ### Changed
 
 ## [0.1.7-alpha]
+
 ### Changed
+
 - Enable build range for 2020.3 EAP
 
 ## [0.1.7-alpha] - 2020-10-14
@@ -207,21 +254,28 @@
 ### Changed
 
 ## [0.1.6-alpha] - 2020-10-07
+
 ### Fixed
+
 - Use application level setting for baseUri if none present for project
 - Add Invoke later for tree build
 
 ### Added
+
 - Ability to toggle Fallthrough variation and Off variation
 
 ## [0.1.5-alpha] - 2020-10-07
+
 ### Fixed
+
 - Changelog
 - Make Java Dependencies Optional
 - Remove deprecated override
 
 ## [0.1.4]
+
 ### Added
+
 - Initial Toolwindow and Treeview to view all of your LaunchDarkly Feature Flags
 - Ability to Toggle flags from the Treeview
 - Open in Browser from any specific flag

--- a/src/main/kotlin/com/launchdarkly/intellij/Utils.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/Utils.kt
@@ -3,6 +3,8 @@ package com.launchdarkly.intellij
 import com.launchdarkly.intellij.settings.LaunchDarklyApplicationConfig
 
 object Utils {
+    const val FLAG_KEY_MAX_LENGTH = 256
+
     fun getFlagUrl(flagKey: String): String {
         val settings = LaunchDarklyApplicationConfig.getInstance().ldState
         return "${settings.baseUri}/${settings.project}/${settings.environment}/features/$flagKey"

--- a/src/main/kotlin/com/launchdarkly/intellij/hover/HoverDocumentationProvider.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/hover/HoverDocumentationProvider.kt
@@ -55,7 +55,10 @@ class HoverDocumentationProvider : AbstractDocumentationProvider() {
     }
 
     override fun getCustomDocumentationElement(
-        editor: Editor, file: PsiFile, contextElement: PsiElement?, offset: Int
+        editor: Editor,
+        file: PsiFile,
+        contextElement: PsiElement?,
+        offset: Int
     ): PsiElement? {
         if (contextElement == null) return null
 

--- a/src/main/kotlin/com/launchdarkly/intellij/hover/HoverDocumentationProvider.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/hover/HoverDocumentationProvider.kt
@@ -7,6 +7,7 @@ import com.intellij.patterns.PlatformPatterns
 import com.intellij.patterns.StandardPatterns
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.launchdarkly.api.model.FeatureFlag
 import com.launchdarkly.intellij.FlagStore
@@ -70,10 +71,11 @@ class HoverDocumentationProvider : AbstractDocumentationProvider() {
     }
 
     override fun generateDoc(element: PsiElement?, originalElement: PsiElement?): String? {
-        // TODO: if element is of type "empty token" then exit immediately.
-        // This can happen when a go project is opened in intellij i.e. when a project type
-        // is unsupported by the IDE flavor.
-        if (element == null || element == StandardPatterns.not(
+        // Immediately exit if there's no PSIElement. In other words, if the language is not supported
+        // by the IDE, then we can't show any docs for it.
+        // https://intellij-support.jetbrains.com/hc/en-us/community/posts/360008223759/comments/360001676819
+        val type = (element as? LeafPsiElement)?.elementType
+        if (type.toString() == "empty token" || element == null || element == StandardPatterns.not(
                 PlatformPatterns.psiElement().notEmpty()
             )
         ) {

--- a/src/main/kotlin/com/launchdarkly/intellij/hover/HoverDocumentationProvider.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/hover/HoverDocumentationProvider.kt
@@ -76,7 +76,7 @@ class HoverDocumentationProvider : AbstractDocumentationProvider() {
         // by the IDE, then we can't show any docs for it.
         // https://intellij-support.jetbrains.com/hc/en-us/community/posts/360008223759/comments/360001676819
         val type = (element as? LeafPsiElement)?.elementType
-        if (element == null || element.language == Language.ANY || element.textLength > 256 || type.toString() == "empty token" || element == StandardPatterns.not(
+        if (element == null || element.language == Language.ANY || element.textLength > Utils.FLAG_KEY_MAX_LENGTH || type.toString() == "empty token" || element == StandardPatterns.not(
                 PlatformPatterns.psiElement().notEmpty()
             )
         ) {

--- a/src/main/kotlin/com/launchdarkly/intellij/hover/HoverDocumentationProvider.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/hover/HoverDocumentationProvider.kt
@@ -1,5 +1,6 @@
 package com.launchdarkly.intellij.hover
 
+import com.intellij.lang.Language
 import com.intellij.lang.documentation.AbstractDocumentationProvider
 import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Editor
@@ -75,7 +76,7 @@ class HoverDocumentationProvider : AbstractDocumentationProvider() {
         // by the IDE, then we can't show any docs for it.
         // https://intellij-support.jetbrains.com/hc/en-us/community/posts/360008223759/comments/360001676819
         val type = (element as? LeafPsiElement)?.elementType
-        if (type.toString() == "empty token" || element == null || element == StandardPatterns.not(
+        if (element == null || element.language == Language.ANY || element.textLength > 256 || type.toString() == "empty token" || element == StandardPatterns.not(
                 PlatformPatterns.psiElement().notEmpty()
             )
         ) {

--- a/src/main/kotlin/com/launchdarkly/intellij/hover/HoverDocumentationProvider.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/hover/HoverDocumentationProvider.kt
@@ -39,7 +39,9 @@ class HoverDocumentationProvider : AbstractDocumentationProvider() {
     }
 
     private fun getElementForDocumentation(contextElement: PsiElement?): PsiElement? {
-        if (contextElement == null || contextElement == StandardPatterns.not(PlatformPatterns.psiElement().notEmpty())
+        if (contextElement == null || contextElement == StandardPatterns.not(
+                PlatformPatterns.psiElement().notEmpty()
+            )
         ) {
             return null
         }
@@ -53,10 +55,7 @@ class HoverDocumentationProvider : AbstractDocumentationProvider() {
     }
 
     override fun getCustomDocumentationElement(
-        editor: Editor,
-        file: PsiFile,
-        contextElement: PsiElement?,
-        offset: Int
+        editor: Editor, file: PsiFile, contextElement: PsiElement?, offset: Int
     ): PsiElement? {
         if (contextElement == null) return null
 
@@ -72,10 +71,12 @@ class HoverDocumentationProvider : AbstractDocumentationProvider() {
     }
 
     override fun generateDoc(element: PsiElement?, originalElement: PsiElement?): String? {
-        // Immediately exit if there's no PSIElement. In other words, if the language is not supported
-        // by the IDE, then we can't show any docs for it.
-        // https://intellij-support.jetbrains.com/hc/en-us/community/posts/360008223759/comments/360001676819
         val type = (element as? LeafPsiElement)?.elementType
+
+        // If a language is not supported, it looks like the IDE labels it as "Language.ANY".
+        // Secondly it is possible that a language is supported but the node contents is the
+        // entire file, hence the second check for max length.
+        // https://intellij-support.jetbrains.com/hc/en-us/community/posts/360008223759/comments/360001676819
         if (element == null || element.language == Language.ANY || element.textLength > Utils.FLAG_KEY_MAX_LENGTH || type.toString() == "empty token" || element == StandardPatterns.not(
                 PlatformPatterns.psiElement().notEmpty()
             )


### PR DESCRIPTION
Immediately exit if there's no PSIElement. In other words, if the language is not supported by the IDE, then we can't show any docs for it.

https://intellij-support.jetbrains.com/hc/en-us/community/posts/360008223759/comments/360001676819