### PR TITLE
[sc-146473] add query params for Links in IntelliJ

### DIFF
--- a/src/main/kotlin/com/launchdarkly/intellij/LaunchDarklyApiClient.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/LaunchDarklyApiClient.kt
@@ -35,7 +35,7 @@ class LaunchDarklyApiClient() {
             val ldBaseUri = if (!baseUri.isNullOrEmpty()) baseUri else getUri(settings.baseUri)
             val ldApiKey = apiKey ?: settings.authorization
             val client: ApiClient = Configuration.getDefaultApiClient()
-            client.setUserAgent(Utils.getPluginVersion())
+            client.setUserAgent(Utils.getUserAgent())
             client.basePath = "$ldBaseUri/api/v2"
             val token = client.getAuthentication("Token") as ApiKeyAuth
             token.apiKey = ldApiKey

--- a/src/main/kotlin/com/launchdarkly/intellij/LaunchDarklyApiClient.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/LaunchDarklyApiClient.kt
@@ -35,7 +35,7 @@ class LaunchDarklyApiClient() {
             val ldBaseUri = if (!baseUri.isNullOrEmpty()) baseUri else getUri(settings.baseUri)
             val ldApiKey = apiKey ?: settings.authorization
             val client: ApiClient = Configuration.getDefaultApiClient()
-            client.setUserAgent("launchdarkly-intellij/${Utils.getPluginVersion()}")
+            client.setUserAgent(Utils.getPluginVersion())
             client.basePath = "$ldBaseUri/api/v2"
             val token = client.getAuthentication("Token") as ApiKeyAuth
             token.apiKey = ldApiKey

--- a/src/main/kotlin/com/launchdarkly/intellij/LaunchDarklyApiClient.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/LaunchDarklyApiClient.kt
@@ -1,7 +1,5 @@
 package com.launchdarkly.intellij
 
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.extensions.PluginId
 import com.launchdarkly.api.ApiClient
 import com.launchdarkly.api.Configuration
 import com.launchdarkly.api.api.AccessTokensApi
@@ -37,10 +35,7 @@ class LaunchDarklyApiClient() {
             val ldBaseUri = if (!baseUri.isNullOrEmpty()) baseUri else getUri(settings.baseUri)
             val ldApiKey = apiKey ?: settings.authorization
             val client: ApiClient = Configuration.getDefaultApiClient()
-            val pluginVersion =
-                PluginManagerCore.getPlugin(PluginId.getId("com.github.intheclouddan.intellijpluginld"))?.version
-                    ?: "noversion"
-            client.setUserAgent("launchdarkly-intellij/$pluginVersion")
+            client.setUserAgent("launchdarkly-intellij/${Utils.getPluginVersion()}")
             client.basePath = "$ldBaseUri/api/v2"
             val token = client.getAuthentication("Token") as ApiKeyAuth
             token.apiKey = ldApiKey

--- a/src/main/kotlin/com/launchdarkly/intellij/Utils.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/Utils.kt
@@ -10,11 +10,11 @@ object Utils {
 
     fun getFlagUrl(flagKey: String): String {
         val settings = LaunchDarklyApplicationConfig.getInstance().ldState
-        return "${settings.baseUri}/${settings.project}/${settings.environment}/features/$flagKey?${getAppQueryParams()}"
+        return "${settings.baseUri}/${settings.project}/${settings.environment}/features/$flagKey?${getQueryParams()}"
     }
 
     fun getUserAgent(): String {
-        return "${ApplicationInfo.getInstance().versionName}/${ApplicationInfo.getInstance().fullVersion} ${getPluginInfo()}"
+        return "${getPluginInfo()} ${ApplicationInfo.getInstance().versionName}/${ApplicationInfo.getInstance().fullVersion}"
     }
 
     fun getIDEVersion(): String {
@@ -26,11 +26,7 @@ object Utils {
             ?: "noversion"}"
     }
 
-    fun getAppQueryParams(): String {
-        return "source=${getIDEVersion()}&pluginVersion=${getPluginInfo()}"
-    }
-
-    fun getDocsQueryParams(): String {
+    fun getQueryParams(): String {
         return "utm_source=${getIDEVersion()}&utm_medium=ide&utm_campaign=${getPluginInfo()}"
     }
 }

--- a/src/main/kotlin/com/launchdarkly/intellij/Utils.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/Utils.kt
@@ -13,20 +13,24 @@ object Utils {
         return "${settings.baseUri}/${settings.project}/${settings.environment}/features/$flagKey?${getAppQueryParams()}"
     }
 
+    fun getUserAgent(): String {
+        return "${ApplicationInfo.getInstance().versionName}/${ApplicationInfo.getInstance().fullVersion} ${getPluginInfo()}"
+    }
+
     fun getIDEVersion(): String {
         return ApplicationInfo.getInstance().fullApplicationName
     }
 
-    fun getPluginVersion(): String {
+    fun getPluginInfo(): String {
         return "launchdarkly-intellij/${PluginManagerCore.getPlugin(PluginId.getId("com.github.intheclouddan.intellijpluginld"))?.version
             ?: "noversion"}"
     }
 
     fun getAppQueryParams(): String {
-        return "source=${getIDEVersion()}&pluginVersion=${getPluginVersion()}"
+        return "source=${getIDEVersion()}&pluginVersion=${getPluginInfo()}"
     }
 
     fun getDocsQueryParams(): String {
-        return "utm_source=${getIDEVersion()}&utm_medium=ide&utm_campaign=${getPluginVersion()}"
+        return "utm_source=${getIDEVersion()}&utm_medium=ide&utm_campaign=${getPluginInfo()}"
     }
 }

--- a/src/main/kotlin/com/launchdarkly/intellij/Utils.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/Utils.kt
@@ -1,5 +1,7 @@
 package com.launchdarkly.intellij
 
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
 import com.launchdarkly.intellij.settings.LaunchDarklyApplicationConfig
 
 object Utils {
@@ -7,6 +9,19 @@ object Utils {
 
     fun getFlagUrl(flagKey: String): String {
         val settings = LaunchDarklyApplicationConfig.getInstance().ldState
-        return "${settings.baseUri}/${settings.project}/${settings.environment}/features/$flagKey"
+        return "${settings.baseUri}/${settings.project}/${settings.environment}/features/$flagKey?${getAppQueryParams()}"
+    }
+
+    fun getPluginVersion(): String {
+        return PluginManagerCore.getPlugin(PluginId.getId("com.github.intheclouddan.intellijpluginld"))?.version
+            ?: "noversion"
+    }
+
+    fun getAppQueryParams(): String {
+        return "source=intellij&version=${getPluginVersion()}"
+    }
+
+    fun getDocsQueryParams(): String {
+        return "utm_source=intellij&utm_medium=ide&utm_campaign=${getPluginVersion()}"
     }
 }

--- a/src/main/kotlin/com/launchdarkly/intellij/Utils.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/Utils.kt
@@ -1,6 +1,7 @@
 package com.launchdarkly.intellij
 
 import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.extensions.PluginId
 import com.launchdarkly.intellij.settings.LaunchDarklyApplicationConfig
 
@@ -12,16 +13,20 @@ object Utils {
         return "${settings.baseUri}/${settings.project}/${settings.environment}/features/$flagKey?${getAppQueryParams()}"
     }
 
+    fun getIDEVersion(): String {
+        return ApplicationInfo.getInstance().fullApplicationName
+    }
+
     fun getPluginVersion(): String {
-        return PluginManagerCore.getPlugin(PluginId.getId("com.github.intheclouddan.intellijpluginld"))?.version
-            ?: "noversion"
+        return "launchdarkly-intellij/${PluginManagerCore.getPlugin(PluginId.getId("com.github.intheclouddan.intellijpluginld"))?.version
+            ?: "noversion"}"
     }
 
     fun getAppQueryParams(): String {
-        return "source=intellij&version=${getPluginVersion()}"
+        return "source=${getIDEVersion()}&pluginVersion=${getPluginVersion()}"
     }
 
     fun getDocsQueryParams(): String {
-        return "utm_source=intellij&utm_medium=ide&utm_campaign=${getPluginVersion()}"
+        return "utm_source=${getIDEVersion()}&utm_medium=ide&utm_campaign=${getPluginVersion()}"
     }
 }

--- a/src/main/kotlin/com/launchdarkly/intellij/toolwindow/LinkNodeRoot.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/toolwindow/LinkNodeRoot.kt
@@ -2,6 +2,7 @@ package com.launchdarkly.intellij.toolwindow
 
 import com.intellij.ide.projectView.PresentationData
 import com.intellij.ui.treeStructure.SimpleNode
+import com.launchdarkly.intellij.Utils
 import com.launchdarkly.intellij.settings.LDSettings
 
 class LinkNodeRoot(private val settings: LDSettings) :
@@ -13,43 +14,43 @@ class LinkNodeRoot(private val settings: LDSettings) :
             myChildren.add(
                 LinkNodeBase(
                     "Flags",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/features"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/features?${Utils.getAppQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Segments",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/segments"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/segments?${Utils.getAppQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Users",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/users"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/users?${Utils.getAppQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Debugger",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/debugger"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/debugger?${Utils.getAppQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Experiments",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/experiments"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/experiments?${Utils.getAppQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Audit Log",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/audit"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/audit?${Utils.getAppQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Flag Comparison",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/features/compare"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/features/compare?${Utils.getAppQueryParams()}"
                 )
             )
             // TODO: Fix selector so we can uncomment this
@@ -62,13 +63,13 @@ class LinkNodeRoot(private val settings: LDSettings) :
             myChildren.add(
                 LinkNodeBase(
                     "Open Documentation",
-                    "https://docs.launchdarkly.com"
+                    "https://docs.launchdarkly.com?${Utils.getDocsQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Open API Documentation",
-                    "https://apidocs.launchdarkly.com"
+                    "https://apidocs.launchdarkly.com?${Utils.getDocsQueryParams()}"
                 )
             )
         }

--- a/src/main/kotlin/com/launchdarkly/intellij/toolwindow/LinkNodeRoot.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/toolwindow/LinkNodeRoot.kt
@@ -14,43 +14,43 @@ class LinkNodeRoot(private val settings: LDSettings) :
             myChildren.add(
                 LinkNodeBase(
                     "Flags",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/features?${Utils.getAppQueryParams()}"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/features?${Utils.getQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Segments",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/segments?${Utils.getAppQueryParams()}"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/segments?${Utils.getQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Users",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/users?${Utils.getAppQueryParams()}"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/users?${Utils.getQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Debugger",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/debugger?${Utils.getAppQueryParams()}"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/debugger?${Utils.getQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Experiments",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/experiments?${Utils.getAppQueryParams()}"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/experiments?${Utils.getQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Audit Log",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/audit?${Utils.getAppQueryParams()}"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/audit?${Utils.getQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Flag Comparison",
-                    "${settings.baseUri}/${settings.project}/${settings.environment}/features/compare?${Utils.getAppQueryParams()}"
+                    "${settings.baseUri}/${settings.project}/${settings.environment}/features/compare?${Utils.getQueryParams()}"
                 )
             )
             // TODO: Fix selector so we can uncomment this
@@ -63,13 +63,13 @@ class LinkNodeRoot(private val settings: LDSettings) :
             myChildren.add(
                 LinkNodeBase(
                     "Open Documentation",
-                    "https://docs.launchdarkly.com?${Utils.getDocsQueryParams()}"
+                    "https://docs.launchdarkly.com?${Utils.getQueryParams()}"
                 )
             )
             myChildren.add(
                 LinkNodeBase(
                     "Open API Documentation",
-                    "https://apidocs.launchdarkly.com?${Utils.getDocsQueryParams()}"
+                    "https://apidocs.launchdarkly.com?${Utils.getQueryParams()}"
                 )
             )
         }


### PR DESCRIPTION
also updated **[user agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent)** for API client to capture IDE info

example: `launchdarkly-intellij/1.0.0-idea21 IntelliJ IDEA/202021.3.1`

**query params**

source is Full IDE version
campaign is plugin version

examples:

`https://apidocs.launchdarkly.com/?utm_source=IntelliJ%20IDEA%202021.3.1&utm_medium=ide&utm_campaign=launchdarkly-intellij/1.0.0-idea21`

`https://app.ld.catamorphic.com/docs/jwhite-dev/audit?utm_source=IntelliJ%20IDEA%202021.3.1&utm_medium=ide&utm_campaign=launchdarkly-intellij/1.0.0-idea21`
