### PR TITLE
Specify api version to 20210729

### DIFF
--- a/src/main/kotlin/com/launchdarkly/intellij/LaunchDarklyApiClient.kt
+++ b/src/main/kotlin/com/launchdarkly/intellij/LaunchDarklyApiClient.kt
@@ -37,6 +37,7 @@ class LaunchDarklyApiClient() {
             val client: ApiClient = Configuration.getDefaultApiClient()
             client.setUserAgent(Utils.getUserAgent())
             client.basePath = "$ldBaseUri/api/v2"
+            client.addDefaultHeader("LD-API-Version", "20210729")
             val token = client.getAuthentication("Token") as ApiKeyAuth
             token.apiKey = ldApiKey
         }


### PR DESCRIPTION
Issue: 
[Shortcut ticket](https://app.shortcut.com/launchdarkly/story/165610/intellij-plugin-set-20210729-api-version-in-all-requests-made-to-ld-s-api)
Customer couldn't change the LD environment in the preferences window with their api token. Support found that using an api token with the api version 20210729 fixed this.
[Support thread on ZenDesk](https://launchdarklysupport.zendesk.com/agent/tickets/23824)

Solution:
I added the header `LD-API-Version: 20210729` for all requests to LaunchDarkly.

Testing:
I tested this by changing the LD environment in the preferences window and applying. It worked, however, I couldn't reproduce the customer's issue.

![CleanShot 2022-08-29 at 17 35 03](https://user-images.githubusercontent.com/58448919/187322636-2ab4ed42-898a-4772-be80-af3f59fb08fb.gif)
