### PR TITLE
Update release.yml to Java 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,12 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v3
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java 17 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       # Cache Gradle dependencies
       - name: Setup Cache


### PR DESCRIPTION
This will fix the error we're seeing during the release GitHub action. We were running it with Java 11. However, we've now upgraded to Java 17.