### PR TITLE
bug: update plugin since build to 241

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.github.intheclouddan.intellijpluginld
 pluginName=intellij-plugin-ld
 pluginVersion=1.0.4-idea24
-pluginSinceBuild=222
+pluginSinceBuild=241
 pluginUntilBuild=241.*
 platformType=IU
 platformVersion=2024.1


### PR DESCRIPTION
Updating `pluginSinceBuild` to 241 as suggested by an error message during build.